### PR TITLE
Support R variables with . and data.frames with $

### DIFF
--- a/R/whisker.R
+++ b/R/whisker.R
@@ -99,10 +99,11 @@ resolve <- function(tag, context, debug=FALSE){
     return(context[[1]])
   }
   
-  #TODO R supports names that have a "."
-  # , so first search for "." and than split
+  # R supports names that have a "." in them
+  # and splits additonal data using a "$"
+  # TODO Should do something similar for slots "@"
   
-  keys <- strsplit(tag, split=".", fixed=TRUE)[[1]]
+  keys <- strsplit(tag, split="$", fixed=TRUE)[[1]]
   if (!length(keys))
     return()
   


### PR DESCRIPTION
I was incorporating whisker into ProjectTemplate at a user request and was having problems handling variables that have '.' in their name as well as referencing columns of a data.frame using the '$' notation.

Sure enough, in the code there was a TODO about this!

The code looks like it is splitting variables on '.' to create nested object method calls. E.g if I pass in `"foo.bar"` the variable name is `foo` and the method name to call on `foo` is `bar`. To the best of my knowledge, method calls on objects in R don't use '.'. 

The common use cases that I'm aware of are using '$' to reference a column of data on a data.frame and using '@' to access a slot on an object. I've updated the code to handle variable names with '.' and to handle the '$' on data.frames. E.g. if I pass in `"foo$bar"` it will take the variable name to be `foo` and the column to return as `bar`. If I pass `"foo.bar"` it will take the variable name to be `foo.bar`.

I didn't make changes for the slots, but made a TODO note.
