### PR TITLE
Make sure conditions are of length 1

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -9,7 +9,7 @@ whisker.markdownToHTML <- function( template
     stop("This function needs the package 'markdown', which can be installed from CRAN.")
   }
   
-  if (is.null(template) || template == ""){
+  if (is.null(template) || identical(template, "")){
     return("")
   }
   

--- a/R/whisker.R
+++ b/R/whisker.R
@@ -19,7 +19,7 @@ whisker.render <- function( template
                           , debug = FALSE
                           , strict = TRUE
                           ){
-   if (is.null(template) || paste(template, collapse="") == ""){
+   if (is.null(template) || identical(paste(template, collapse=""), "")){
      return("")
    }
    


### PR DESCRIPTION
Several downstream packages are seeing errors when the new `_R_CHECK_LENGTH_1_LOGIC2_` is set to "true". We can presumably all work around it but it would be great to fix this problem at the source.

Examples:

https://github.com/r-lib/usethis/issues/786
https://github.com/r-lib/pkgdown/issues/1064
https://github.com/tidyverse/reprex/issues/267