### PR TITLE
Reword Description field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,7 @@ Title: {{mustache}} for R, logicless templating
 Type: Package
 LazyLoad: yes
 Author: Edwin de Jonge
-Description: logicless templating, reuse templates in many
-    programming languages including R
+Description: Implements 'Mustache' logicless templating.
 Version: 0.4
 URL: http://github.com/edwindj/whisker
 Date: 2010-12-23


### PR DESCRIPTION
Clears this NOTE

```
* checking DESCRIPTION meta-information ... NOTE
Malformed Description field: should contain one or more complete sentences.
```